### PR TITLE
fix: PhysicalMaterial::is_transparent() only checks the field

### DIFF
--- a/src/renderer/material/physical_material.rs
+++ b/src/renderer/material/physical_material.rs
@@ -177,7 +177,7 @@ impl PhysicalMaterial {
 
     /// Returns whether this material is a transparent material
     pub fn is_transparent(&self) -> bool {
-        self.is_transparent || self.albedo.a < 255
+        self.is_transparent
     }
 }
 


### PR DESCRIPTION
Previously is_transparent() returned `self.is_transparent || self.albedo.a < 255`, forcing OIT even when the caller set `is_transparent = false`.

OIT weight overflow causes white blowout on light-colored geometry. Now returns only `self.is_transparent` so callers can use standard alpha blend.